### PR TITLE
Add basic Node backend for appointments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # ttGreatNailsWebsite
+
+This repo now includes a small Node.js backend for handling appointment bookings from `bookAppt.html`.
+
+## Running the server
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set the following environment variables:
+   - `GOOGLE_APPLICATION_CREDENTIALS` – path to a Google service account JSON key with Calendar permissions.
+   - `CALENDAR_ID` – ID of the Google Calendar to insert events into.
+   - `PORT` (optional) – port for the server (default `3000`).
+3. Start the server:
+   ```bash
+   npm start
+   ```
+
+The booking form will POST to `/api/book`, and successful submissions will create events in your Google Calendar.

--- a/bookAppt.js
+++ b/bookAppt.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const {google} = require('googleapis');
+const app = express();
+
+app.use(bodyParser.json());
+
+function getCalendarClient() {
+  const auth = new google.auth.GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/calendar'],
+    keyFile: process.env.GOOGLE_APPLICATION_CREDENTIALS
+  });
+  return google.calendar({version: 'v3', auth});
+}
+
+app.post('/api/book', async (req, res) => {
+  const {name, ucontact, uemail, date, time, services, message} = req.body;
+  try {
+    const calendar = getCalendarClient();
+    const start = new Date(`${date}T${time}`);
+    const end = new Date(start.getTime() + 60 * 60 * 1000); // default 1h
+    const event = {
+      summary: `Appointment with ${name}`,
+      description: `Services: ${services.join(', ')}\nContact: ${ucontact}\nEmail: ${uemail}\n${message || ''}`,
+      start: {dateTime: start.toISOString()},
+      end: {dateTime: end.toISOString()}
+    };
+    await calendar.events.insert({
+      calendarId: process.env.CALENDAR_ID,
+      resource: event
+    });
+    res.json({status: 'ok'});
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Failed to create event');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ttgreatnails-backend",
+  "version": "1.0.0",
+  "main": "bookAppt.js",
+  "scripts": {
+    "start": "node bookAppt.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2",
+    "googleapis": "^132.0.0"
+  }
+}

--- a/ttgreatnail/webpages/bookAppt.js
+++ b/ttgreatnail/webpages/bookAppt.js
@@ -533,3 +533,33 @@ app.directive('datePicker', function ($timeout, $window) {
         }
     };
 });
+// Appointment form submission
+document.getElementById("appoint-form").addEventListener("submit", async function(e) {
+  e.preventDefault();
+  const serviceEls = document.querySelectorAll("#dropdown-container select, .extra-dropdown select");
+  const services = Array.from(serviceEls).map(s => s.value).filter(v => v && v !== "apptType");
+  const payload = {
+    services,
+    date: document.getElementById("date").value,
+    time: document.getElementById("time").value,
+    name: document.getElementById("name").value,
+    ucontact: document.getElementById("mobile").value,
+    uemail: document.getElementById("email").value,
+    message: document.getElementById("message").value
+  };
+  try {
+    const res = await fetch("/api/book", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(payload)
+    });
+    if (res.ok) {
+      alert("Appointment booked!");
+    } else {
+      alert("Failed to book appointment");
+    }
+  } catch (err) {
+    console.error(err);
+    alert("Error booking appointment");
+  }
+});


### PR DESCRIPTION
## Summary
- add appointment booking server using Express and Google Calendar API
- send appointment form data with new JS logic
- document running the Node backend

## Testing
- `node -c bookAppt.js`
- `node bookAppt.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6880769ea028832182442a2c5b3b4625